### PR TITLE
docs: correct minimum Node.js version in prerequisites (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (v14 or above)
+- [Node.js](https://nodejs.org/) (v18 or above)
 - [Go](https://golang.org/) (v1.16 or above)
 - [Docker](https://www.docker.com/)
 - [PostgreSQL](https://www.postgresql.org/)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (v18 or above)
+- [Node.js](https://nodejs.org/) (v20.9.0 or above)
 - [Go](https://golang.org/) (v1.16 or above)
 - [Docker](https://www.docker.com/)
 - [PostgreSQL](https://www.postgresql.org/)


### PR DESCRIPTION
Updates the minimum Node.js version from v14 to v18, matching the actual requirement of the Next.js frontend.

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README installation prerequisites to require **Node.js v20.9.0 or above** (previously indicated an older Node.js version).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->